### PR TITLE
Fix compressToUTF16Async

### DIFF
--- a/src/component/lz-string/lz-string.js
+++ b/src/component/lz-string/lz-string.js
@@ -59,9 +59,9 @@ var LZStringGenerator = (function () {
 
         compressToUTF16: function* (input) {
             if (input === null) return ''
-            return yield* LZString._compress(input, 15, function (a) {
+            return (yield* LZString._compress(input, 15, function (a) {
                 return f(a + 32)
-            }) + ' '
+            })) + ' '
         },
 
         decompressFromUTF16: function* (compressed) {

--- a/src/test/compression.test.js
+++ b/src/test/compression.test.js
@@ -1,5 +1,5 @@
 import {should} from 'chai'
-import {compressAsync, decompressAsync, sortAsync} from '../component'
+import {compressAsync, decompressAsync, compressToUTF16Async, decompressFromUTF16Async, sortAsync} from '../component'
 
 should()
 const INPUT_ARRAY = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]
@@ -11,5 +11,11 @@ describe('compression', function () {
         let output = await decompressAsync(result)
         output.should.eq('abcde')
         result.should.eq('ↂテɠꙀ')
+    })
+    it('should compress a string to UTF 16', async function () {
+        let result = await compressToUTF16Async('abcde')
+        let output = await decompressFromUTF16Async(result)
+        output.should.eq('abcde')
+        result.should.eq('ს౑䁬઄  ')
     })
 })


### PR DESCRIPTION
`compressToUTF16Async` was returning `undefined` for me without this fix. The fix just adds a couple brackets to fix the order of operations on the string concatenation.

I've also added a test case for UTF-16 compression. You can see that the test case fails without the fix.